### PR TITLE
refactor: do not attempt to refresh invalid token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testquality/sdk",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "description": "SDK for accessing TestQuality API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -289,16 +289,15 @@ export class Auth {
   ): Promise<ReturnToken | undefined> {
     if (this.refreshRequest) {
       debug('refresh: in process');
-      // TODO @david
-      // what if this errors?
-      // we are handling errors inside refreshRequest
-      // but not here, does that mean that other requests
-      // waiting other than the one that originated the
-      // refresh will have unhandled errors?
-      return await this.refreshRequest.then(async ({ data }) => {
-        debug('refresh: resolved');
-        return data;
-      });
+      return await this.refreshRequest
+        .then(async ({ data }) => {
+          debug('refresh: resolved');
+          return data;
+        })
+        .catch((err) => {
+          debug('refresh: error', err);
+          return undefined;
+        });
     }
 
     let token = refreshToken;

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -99,7 +99,7 @@ export class Auth {
    * authenticated, possible values:
    *  true - user is authenticated
    *  false - user failed to authenticate
-   *  null - user has not attempted to authenticate yet
+   *  undefined - user has not attempted to authenticate yet
    */
   private authenticated: boolean | undefined;
   private checkSubscriptionRequest?: Promise<ReturnToken | undefined>;

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -12,7 +12,6 @@ import {
   getHttpResponse,
   HttpError,
   NO_REFRESH_TOKEN,
-  // INVALID_REFRESH_TOKEN,
 } from '../exceptions';
 import { type ClientSdk } from '../ClientSdk';
 import { getSubscriptionEntitlement } from '../services/auth';

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -448,7 +448,8 @@ export class Auth {
     if (token) {
       Auth.validateTokenPayload(token);
     }
-    if (token?.expires_in) {
+    // if we are setting a token that already has an expires_at, we should not override it
+    if (token?.expires_in && !token?.expires_at) {
       const now = new Date();
       now.setSeconds(now.getSeconds() + (token.expires_in - 15)); // subtract 15 seconds to guard against latency
       token.expires_at = JSON.parse(JSON.stringify(now));

--- a/src/exceptions/handleHttpError.ts
+++ b/src/exceptions/handleHttpError.ts
@@ -4,6 +4,7 @@ import { _client } from '../ClientSdk';
 
 export const UNKNOWN_ERROR = 'UNKNOWN_ERROR';
 export const NO_REFRESH_TOKEN = 'NO_REFRESH_TOKEN';
+export const REFRESH_TOKEN_ERROR = 'REFRESH_TOKEN_ERROR';
 export const UNAUTHORIZED = 'UNAUTHORIZED';
 export const VALIDATION_ERROR = 'VALIDATION_ERROR';
 export const EMAIL_VERIFICATION_ERROR = 'EMAIL_VERIFICATION_ERROR';

--- a/src/exceptions/handleHttpError.ts
+++ b/src/exceptions/handleHttpError.ts
@@ -3,6 +3,7 @@ import { HttpError } from './HttpError';
 import { _client } from '../ClientSdk';
 
 export const UNKNOWN_ERROR = 'UNKNOWN_ERROR';
+export const NO_ACCESS_TOKEN = 'NO_ACCESS_TOKEN';
 export const NO_REFRESH_TOKEN = 'NO_REFRESH_TOKEN';
 export const REFRESH_TOKEN_ERROR = 'REFRESH_TOKEN_ERROR';
 export const UNAUTHORIZED = 'UNAUTHORIZED';


### PR DESCRIPTION
Added state to track token authentication. We try to avoid making unnecessary requests when sending refresh token requests due to unauthorized errors. Unauthorized errors intercepted cause a refresh request to be sent always, but it might be the case that a refresh request is already on-going while several others (that require authorization) are sent while the refresh one hasn't resolved yet, leading to further errors as we haven't obtained a new token yet.